### PR TITLE
docs: add core reference examples

### DIFF
--- a/R/coord-psychro.R
+++ b/R/coord-psychro.R
@@ -2,6 +2,24 @@
 #'
 #' @inheritParams ggplot2::coord_cartesian
 #' @inheritParams ggpsychro
+#' @examples
+#' ggpsychro() +
+#'     coord_psychro(tdb_lim = c(10, 35), hum_lim = c(0, 25))
+#'
+#' ggpsychro(units = "IP", altitude = 1000) +
+#'     coord_psychro(
+#'         tdb_lim = c(50, 100),
+#'         hum_lim = c(0, 140),
+#'         units = "IP",
+#'         altitude = 1000
+#'     )
+#'
+#' ggpsychro(mollier = TRUE) +
+#'     coord_psychro(
+#'         tdb_lim = c(0, 50),
+#'         hum_lim = c(0, 30),
+#'         mollier = TRUE
+#'     )
 #' @export
 coord_psychro <- function(tdb_lim = NULL, hum_lim = NULL,
                           altitude = NULL, units = NULL, mollier = NULL,

--- a/R/grid-layer.R
+++ b/R/grid-layer.R
@@ -18,6 +18,26 @@
 #' @param label_parse If `TRUE`, labels are parsed as plotmath expressions.
 #'
 #' @rdname geom_grid
+#' @examples
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     geom_grid_relhum() +
+#'     geom_grid_wetbulb() +
+#'     geom_grid_enthalpy()
+#'
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     geom_grid_relhum(color = "black", linewidth = 0.6, label.size = 4) +
+#'     scale_relhum_continuous(
+#'         breaks = seq(25, 75, by = 25),
+#'         minor_breaks = NULL
+#'     ) +
+#'     geom_grid_wetbulb(color = "black", label = FALSE) +
+#'     scale_wetbulb_continuous(
+#'         breaks = seq(10, 30, by = 10),
+#'         minor_breaks = NULL
+#'     ) +
+#'     geom_grid_vappres(show = FALSE) +
+#'     geom_grid_specvol(label_loc = 0.90) +
+#'     geom_grid_enthalpy(label.size = 4)
 #' @export
 geom_grid_relhum <- function(..., show = TRUE, label = TRUE, label_loc = 0.95,
                              label_parse = FALSE) {

--- a/R/psychro-state.R
+++ b/R/psychro-state.R
@@ -17,6 +17,33 @@ NULL
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_path
 #' @rdname psychro_state
+#' @examples
+#' process <- data.frame(
+#'     state = c("outdoor", "mixed", "supply", "room"),
+#'     tdb = c(18, 23, 28, 31),
+#'     relhum = c(70, 55, 45, 55)
+#' )
+#'
+#' # Draw state points. Map exactly one psychrometric property with tdb.
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     stat_psychro_state(
+#'         aes(tdb = tdb, relhum = relhum, colour = state),
+#'         data = process
+#'     )
+#'
+#' # Draw the same states as a process line.
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     geom_psychro_process(
+#'         aes(tdb = tdb, relhum = relhum),
+#'         data = process,
+#'         linewidth = 1,
+#'         arrow = grid::arrow(length = grid::unit(0.08, "inches"))
+#'     ) +
+#'     stat_psychro_state(
+#'         aes(tdb = tdb, relhum = relhum),
+#'         data = process,
+#'         size = 2
+#'     )
 #' @export
 geom_psychro_process <- function(mapping = NULL, data = NULL, stat = "psychro_state",
                                  position = "identity", ..., na.rm = FALSE,

--- a/R/psychro-zone.R
+++ b/R/psychro-zone.R
@@ -26,6 +26,85 @@ NULL
 #' @param n Number of samples used for computed zone boundaries.
 #'
 #' @rdname psychro_zone
+#' @examples
+#' comfort <- data.frame(
+#'     name = c("cool", "warm"),
+#'     tdb_min = c(20, 24),
+#'     tdb_max = c(26, 32),
+#'     relhum_min = c(35, 45),
+#'     relhum_max = c(60, 75)
+#' )
+#'
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     geom_psychro_zone(
+#'         aes(tdb_min = tdb_min, tdb_max = tdb_max,
+#'             relhum_min = relhum_min, relhum_max = relhum_max,
+#'             fill = name),
+#'         data = comfort,
+#'         type = "dbt-rh",
+#'         alpha = 0.28,
+#'         colour = NA
+#'     )
+#'
+#' # Dry-bulb range with humidity-ratio limits.
+#' humidity_cap <- data.frame(
+#'     tdb_min = 10,
+#'     tdb_max = 34,
+#'     humratio_min = 4,
+#'     humratio_max = 12
+#' )
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     geom_psychro_zone(
+#'         aes(tdb_min = tdb_min, tdb_max = tdb_max,
+#'             humratio_min = humratio_min, humratio_max = humratio_max),
+#'         data = humidity_cap,
+#'         type = "dbt-wmax",
+#'         alpha = 0.25
+#'     )
+#'
+#' # Property-bounded zones.
+#' enthalpy_zone <- data.frame(
+#'     enthalpy_min = 40000,
+#'     enthalpy_max = 65000,
+#'     relhum_min = 30,
+#'     relhum_max = 80
+#' )
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     geom_psychro_zone(
+#'         aes(enthalpy_min = enthalpy_min, enthalpy_max = enthalpy_max,
+#'             relhum_min = relhum_min, relhum_max = relhum_max),
+#'         data = enthalpy_zone,
+#'         type = "enthalpy-rh",
+#'         alpha = 0.25
+#'     )
+#'
+#' volume_zone <- data.frame(
+#'     specvol_min = 0.84,
+#'     specvol_max = 0.90,
+#'     relhum_min = 30,
+#'     relhum_max = 90
+#' )
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     geom_psychro_zone(
+#'         aes(specvol_min = specvol_min, specvol_max = specvol_max,
+#'             relhum_min = relhum_min, relhum_max = relhum_max),
+#'         data = volume_zone,
+#'         type = "specvol-rh",
+#'         alpha = 0.25
+#'     )
+#'
+#' # Draw an already-specified polygon in chart display units.
+#' polygon_zone <- data.frame(
+#'     tdb = c(20, 26, 28),
+#'     humratio = c(6, 8, 6)
+#' )
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     geom_psychro_zone(
+#'         aes(tdb = tdb, humratio = humratio),
+#'         data = polygon_zone,
+#'         type = "xy-points",
+#'         alpha = 0.25
+#'     )
 #' @export
 geom_psychro_zone <- function(mapping = NULL, data = NULL, stat = "psychro_zone",
                               position = "identity", ..., type = "dbt-rh",

--- a/R/stat.R
+++ b/R/stat.R
@@ -20,8 +20,8 @@
 #' All of stats above requires two additional aesthetics:
 #'
 #' * `units`: A single string indicating the unit system to use. Should be
-#'   either `"SI"` or `"IP" or `waiver()` which uses the value from the parent
-#'   plot. Default: `waiver()`
+#'   either `"SI"` or `"IP"`, or `waiver()` which uses the value from the
+#'   parent plot. Default: `waiver()`
 #'
 #' * `pres`: A single number indicating the atmosphere pressure in Pa \[SI\] or
 #'   Psi \[IP\]. If `waiver()`, the pressure calculated from the parent plot's
@@ -34,6 +34,44 @@
 #' @inheritParams ggplot2::geom_point
 #' @importFrom ggplot2 ggproto Stat Geom
 #' @rdname stat
+#' @examples
+#' states <- data.frame(
+#'     tdb = c(18, 22, 26, 30),
+#'     relhum = c(70, 55, 45, 35)
+#' )
+#'
+#' ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+#'     stat_relhum(aes(x = tdb, relhum = relhum), data = states)
+#'
+#' # The stats can also be used from ordinary ggplot2 geoms.
+#' wetbulb_line <- data.frame(tdb = 18:30, wetbulb = 16)
+#' ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+#'     geom_grid_wetbulb() +
+#'     geom_line(aes(x = tdb, wetbulb = wetbulb),
+#'         data = wetbulb_line, stat = "wetbulb")
+#'
+#' vapour_pressure <- data.frame(
+#'     tdb = c(12, 18, 24, 30),
+#'     vappres = c(900, 1200, 1800, 2400)
+#' )
+#' ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+#'     stat_vappres(aes(x = tdb, vappres = vappres),
+#'         data = vapour_pressure)
+#'
+#' specific_volume <- data.frame(
+#'     tdb = c(20, 25, 30),
+#'     specvol = c(0.84, 0.86, 0.88)
+#' )
+#' ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+#'     stat_specvol(aes(x = tdb, specvol = specvol),
+#'         data = specific_volume)
+#'
+#' enthalpy <- data.frame(
+#'     tdb = c(18, 24, 30),
+#'     enthalpy = c(35000, 50000, 65000)
+#' )
+#' ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+#'     stat_enthalpy(aes(x = tdb, enthalpy = enthalpy), data = enthalpy)
 #'
 #' @export
 stat_relhum <- function (mapping = NULL, data = NULL, geom = "point", position = "identity",
@@ -255,6 +293,8 @@ StatEnthalpy <- ggproto(
     compute_group = function (self, data, scales) {
         units <- get_units(data)
         ys <- names(data)[names(data) %in% GGPSY_OPT$y_aes]
+
+        if (!length(ys)) ys <- "y"
 
         for (var in ys) {
             data[[var]] <- with_units(units, GetHumRatioFromEnthalpyAndTDryBulb(data$enthalpy, data$x))

--- a/man/coord_psychro.Rd
+++ b/man/coord_psychro.Rd
@@ -64,3 +64,22 @@ legend, the plot title, or the plot margins.}
 \description{
 Psychrometric coordinates
 }
+\examples{
+ggpsychro() +
+    coord_psychro(tdb_lim = c(10, 35), hum_lim = c(0, 25))
+
+ggpsychro(units = "IP", altitude = 1000) +
+    coord_psychro(
+        tdb_lim = c(50, 100),
+        hum_lim = c(0, 140),
+        units = "IP",
+        altitude = 1000
+    )
+
+ggpsychro(mollier = TRUE) +
+    coord_psychro(
+        tdb_lim = c(0, 50),
+        hum_lim = c(0, 30),
+        mollier = TRUE
+    )
+}

--- a/man/geom_grid.Rd
+++ b/man/geom_grid.Rd
@@ -71,3 +71,24 @@ These helpers provide ggplot-style controls for psychrometric reference
 grids. They do not add data layers; they mark a grid as visible and let
 \code{\link[=coord_psychro]{coord_psychro()}} render it in the panel background.
 }
+\examples{
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    geom_grid_relhum() +
+    geom_grid_wetbulb() +
+    geom_grid_enthalpy()
+
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    geom_grid_relhum(color = "black", linewidth = 0.6, label.size = 4) +
+    scale_relhum_continuous(
+        breaks = seq(25, 75, by = 25),
+        minor_breaks = NULL
+    ) +
+    geom_grid_wetbulb(color = "black", label = FALSE) +
+    scale_wetbulb_continuous(
+        breaks = seq(10, 30, by = 10),
+        minor_breaks = NULL
+    ) +
+    geom_grid_vappres(show = FALSE) +
+    geom_grid_specvol(label_loc = 0.90) +
+    geom_grid_enthalpy(label.size = 4)
+}

--- a/man/psychro_state.Rd
+++ b/man/psychro_state.Rd
@@ -143,3 +143,31 @@ The \code{tdb} aesthetic is required. Exactly one of \code{humratio}, \code{relh
 \code{relhum} is supplied in percent. \code{humratio} is supplied in chart display
 units: g/kg in SI and gr/lb in IP.
 }
+\examples{
+process <- data.frame(
+    state = c("outdoor", "mixed", "supply", "room"),
+    tdb = c(18, 23, 28, 31),
+    relhum = c(70, 55, 45, 55)
+)
+
+# Draw state points. Map exactly one psychrometric property with tdb.
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    stat_psychro_state(
+        aes(tdb = tdb, relhum = relhum, colour = state),
+        data = process
+    )
+
+# Draw the same states as a process line.
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    geom_psychro_process(
+        aes(tdb = tdb, relhum = relhum),
+        data = process,
+        linewidth = 1,
+        arrow = grid::arrow(length = grid::unit(0.08, "inches"))
+    ) +
+    stat_psychro_state(
+        aes(tdb = tdb, relhum = relhum),
+        data = process,
+        size = 2
+    )
+}

--- a/man/psychro_zone.Rd
+++ b/man/psychro_zone.Rd
@@ -158,3 +158,83 @@ Supported zone types are:
 \code{relhum} values are supplied in percent. \code{humratio} values are supplied in
 chart display units: g/kg in SI and gr/lb in IP.
 }
+\examples{
+comfort <- data.frame(
+    name = c("cool", "warm"),
+    tdb_min = c(20, 24),
+    tdb_max = c(26, 32),
+    relhum_min = c(35, 45),
+    relhum_max = c(60, 75)
+)
+
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    geom_psychro_zone(
+        aes(tdb_min = tdb_min, tdb_max = tdb_max,
+            relhum_min = relhum_min, relhum_max = relhum_max,
+            fill = name),
+        data = comfort,
+        type = "dbt-rh",
+        alpha = 0.28,
+        colour = NA
+    )
+
+# Dry-bulb range with humidity-ratio limits.
+humidity_cap <- data.frame(
+    tdb_min = 10,
+    tdb_max = 34,
+    humratio_min = 4,
+    humratio_max = 12
+)
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    geom_psychro_zone(
+        aes(tdb_min = tdb_min, tdb_max = tdb_max,
+            humratio_min = humratio_min, humratio_max = humratio_max),
+        data = humidity_cap,
+        type = "dbt-wmax",
+        alpha = 0.25
+    )
+
+# Property-bounded zones.
+enthalpy_zone <- data.frame(
+    enthalpy_min = 40000,
+    enthalpy_max = 65000,
+    relhum_min = 30,
+    relhum_max = 80
+)
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    geom_psychro_zone(
+        aes(enthalpy_min = enthalpy_min, enthalpy_max = enthalpy_max,
+            relhum_min = relhum_min, relhum_max = relhum_max),
+        data = enthalpy_zone,
+        type = "enthalpy-rh",
+        alpha = 0.25
+    )
+
+volume_zone <- data.frame(
+    specvol_min = 0.84,
+    specvol_max = 0.90,
+    relhum_min = 30,
+    relhum_max = 90
+)
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    geom_psychro_zone(
+        aes(specvol_min = specvol_min, specvol_max = specvol_max,
+            relhum_min = relhum_min, relhum_max = relhum_max),
+        data = volume_zone,
+        type = "specvol-rh",
+        alpha = 0.25
+    )
+
+# Draw an already-specified polygon in chart display units.
+polygon_zone <- data.frame(
+    tdb = c(20, 26, 28),
+    humratio = c(6, 8, 6)
+)
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    geom_psychro_zone(
+        aes(tdb = tdb, humratio = humratio),
+        data = polygon_zone,
+        type = "xy-points",
+        alpha = 0.25
+    )
+}

--- a/man/stat.Rd
+++ b/man/stat.Rd
@@ -178,7 +178,8 @@ values in each group.
 All of stats above requires two additional aesthetics:
 \itemize{
 \item \code{units}: A single string indicating the unit system to use. Should be
-either \code{"SI"} or \verb{"IP" or }waiver()\verb{which uses the value from the parent plot. Default:}waiver()`
+either \code{"SI"} or \code{"IP"}, or \code{waiver()} which uses the value from the
+parent plot. Default: \code{waiver()}
 \item \code{pres}: A single number indicating the atmosphere pressure in Pa [SI] or
 Psi [IP]. If \code{waiver()}, the pressure calculated from the parent plot's
 altitude value will be used. Default: \code{waiver()}
@@ -186,4 +187,44 @@ altitude value will be used. Default: \code{waiver()}
 
 However, when these stats are used inside a ggplot \verb{geom_*} as the \code{stat}
 argument, both \code{units} and \code{pres} have to be specified.
+}
+\examples{
+states <- data.frame(
+    tdb = c(18, 22, 26, 30),
+    relhum = c(70, 55, 45, 35)
+)
+
+ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+    stat_relhum(aes(x = tdb, relhum = relhum), data = states)
+
+# The stats can also be used from ordinary ggplot2 geoms.
+wetbulb_line <- data.frame(tdb = 18:30, wetbulb = 16)
+ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+    geom_grid_wetbulb() +
+    geom_line(aes(x = tdb, wetbulb = wetbulb),
+        data = wetbulb_line, stat = "wetbulb")
+
+vapour_pressure <- data.frame(
+    tdb = c(12, 18, 24, 30),
+    vappres = c(900, 1200, 1800, 2400)
+)
+ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+    stat_vappres(aes(x = tdb, vappres = vappres),
+        data = vapour_pressure)
+
+specific_volume <- data.frame(
+    tdb = c(20, 25, 30),
+    specvol = c(0.84, 0.86, 0.88)
+)
+ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+    stat_specvol(aes(x = tdb, specvol = specvol),
+        data = specific_volume)
+
+enthalpy <- data.frame(
+    tdb = c(18, 24, 30),
+    enthalpy = c(35000, 50000, 65000)
+)
+ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+    stat_enthalpy(aes(x = tdb, enthalpy = enthalpy), data = enthalpy)
+
 }

--- a/tests/testthat/test-ggpsychro.R
+++ b/tests/testthat/test-ggpsychro.R
@@ -419,3 +419,25 @@ test_that("Psychrometric stats inherit units and pressure from the plot", {
     expect_equal(built$data[[1L]]$y, expected, tolerance = 1e-8)
     expect_gt(max(built$data[[1L]]$y), 0.01)
 })
+
+test_that("Enthalpy stat creates y output without an explicit y aesthetic", {
+    d <- data.frame(
+        dry_bulb_temperature = c(18, 24, 30),
+        enthalpy = c(35000, 50000, 65000)
+    )
+
+    built <- ggplot2::ggplot_build(
+        ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+            stat_enthalpy(
+                ggplot2::aes(x = dry_bulb_temperature, enthalpy = enthalpy),
+                data = d
+            )
+    )
+    expected <- with_units(
+        "SI",
+        GetHumRatioFromEnthalpyAndTDryBulb(d$enthalpy, d$dry_bulb_temperature)
+    )
+
+    expect_equal(built$data[[1L]]$y, expected, tolerance = 1e-8)
+    expect_true(all(is.finite(built$data[[1L]]$y)))
+})


### PR DESCRIPTION
## Summary
- Add runnable core reference examples for psychrometric stats, state/process layers, zones, grid helpers, and explicit coordinates.
- Keep the documentation roxygen-first and regenerate the affected Rd pages from source.

## Changes
- Document stat_relhum(), stat_wetbulb(), stat_vappres(), stat_specvol(), stat_enthalpy(), stat_psychro_state(), geom_psychro_process(), geom_psychro_zone(), geom_grid_*(), and coord_psychro() with small in-package examples.
- Align StatEnthalpy with the other psychrometric stats by creating default y output when no y aesthetic is mapped, with regression coverage.