### PR TITLE
docs: add comfort and protractor guides

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggpsychro 0.0.0.9000
 
+* Added README and pkgdown documentation for comfort overlays and the
+  psychrometric protractor. (#22)
 * Added an ASHRAE-style psychrometric protractor for sensible heat ratio and
   heat-moisture-ratio guides, including Mollier rotation support, overall
   scaling, and independent mask-area margins. (#21)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # ggpsychro 0.0.0.9000
 
+* Added an ASHRAE-style psychrometric protractor for sensible heat ratio and
+  heat-moisture-ratio guides, including Mollier rotation support, overall
+  scaling, and independent mask-area margins. (#21)
+* Added thermal comfort calculations and comfort overlay layers for PMV/PPD,
+  SET, adaptive comfort, PMV curves, PMV-based ASHRAE 55 / EN 15251 comfort
+  zones, and point-state comfort metrics. (#20)
+* Removed an ambiguous `specvol-rh` zone example from the reference
+  documentation. (#19)
+* Clipped `geom_psychro_tile()` bodies to the saturation curve so tiles stay
+  inside the valid psychrometric region. (#17)
+* Added runnable core reference examples for psychrometric stats, grid helpers,
+  state/process layers, zones, and explicit coordinates. (#18)
 * Added website-only pkgdown articles and shortened the README. (#15)
 * Added psychrometric tile bins. (#14)
 * Added psychrometric chart presets. (#12)

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,6 +30,8 @@ knitr::opts_chunk$set(
 
 * ggplot2-native psychrometric charts with SI/IP units and Mollier orientation.
 * Preset grid and style helpers for common psychrometric chart layouts.
+* ASHRAE-style psychrometric protractor for sensible heat ratio and
+  heat-moisture-ratio guides in the chart mask area.
 * Psychrometric stats for relative humidity, wet-bulb temperature, vapor
   pressure, specific volume, enthalpy, and humidity ratio.
 * State points, process lines, and filled operating zones for HVAC workflows.
@@ -83,11 +85,14 @@ The longer examples live on the pkgdown site:
   ggplot layers.
 * [Chart grids and styles](https://hongyuanjia.github.io/ggpsychro/articles/grids-and-styles.html) -
   tune dry-bulb, humidity-ratio, relative-humidity, wet-bulb, enthalpy, and
-  specific-volume grid guides.
+  specific-volume grid guides, plus the psychrometric protractor.
 * [Plotting psychrometric data](https://hongyuanjia.github.io/ggpsychro/articles/plotting-data.html) -
   plot points, bins, and overlays from weather or measured state data.
+* [Comfort overlays](https://hongyuanjia.github.io/ggpsychro/articles/comfort-overlays.html) -
+  draw PMV, SET, adaptive comfort, and PMV-based standard comfort overlays.
 * [Zones and processes](https://hongyuanjia.github.io/ggpsychro/articles/zones-and-processes.html) -
-  draw comfort regions, operating limits, state points, and HVAC process lines.
+  draw manual comfort regions, operating limits, state points, and HVAC process
+  lines.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ status](https://www.r-pkg.org/badges/version/ggpsychro)](https://CRAN.R-project.
 - ggplot2-native psychrometric charts with SI/IP units and Mollier
   orientation.
 - Preset grid and style helpers for common psychrometric chart layouts.
+- ASHRAE-style psychrometric protractor for sensible heat ratio and
+  heat-moisture-ratio guides in the chart mask area.
 - Psychrometric stats for relative humidity, wet-bulb temperature, vapor
   pressure, specific volume, enthalpy, and humidity ratio.
 - State points, process lines, and filled operating zones for HVAC
@@ -80,14 +82,18 @@ The longer examples live on the pkgdown site:
 - [Chart grids and
   styles](https://hongyuanjia.github.io/ggpsychro/articles/grids-and-styles.html) -
   tune dry-bulb, humidity-ratio, relative-humidity, wet-bulb, enthalpy,
-  and specific-volume grid guides.
+  and specific-volume grid guides, plus the psychrometric protractor.
 - [Plotting psychrometric
   data](https://hongyuanjia.github.io/ggpsychro/articles/plotting-data.html) -
   plot points, bins, and overlays from weather or measured state data.
+- [Comfort
+  overlays](https://hongyuanjia.github.io/ggpsychro/articles/comfort-overlays.html) -
+  draw PMV, SET, adaptive comfort, and PMV-based standard comfort
+  overlays.
 - [Zones and
   processes](https://hongyuanjia.github.io/ggpsychro/articles/zones-and-processes.html) -
-  draw comfort regions, operating limits, state points, and HVAC process
-  lines.
+  draw manual comfort regions, operating limits, state points, and HVAC
+  process lines.
 
 ## Author
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -14,6 +14,7 @@ articles:
   contents:
   - articles/grids-and-styles
   - articles/plotting-data
+  - articles/comfort-overlays
   - articles/zones-and-processes
 
 navbar:

--- a/vignettes/articles/comfort-overlays.Rmd
+++ b/vignettes/articles/comfort-overlays.Rmd
@@ -1,0 +1,130 @@
+---
+title: "Comfort overlays"
+---
+
+```{r setup, include = FALSE}
+library(ggpsychro)
+knitr::opts_chunk$set(
+    collapse = TRUE,
+    comment = "#>",
+    fig.align = "center",
+    out.width = "100%",
+    fig.width = 9,
+    fig.height = 6,
+    dev = "png",
+    dpi = 120
+)
+```
+
+Comfort overlay layers evaluate thermal comfort models on the current
+psychrometric panel. They inherit the chart units, pressure, limits, and
+Mollier orientation from `ggpsychro()`, so comfort regions can be composed with
+the same `+` workflow as other ggplot layers.
+
+## PMV overlays
+
+The default comfort model is ISO 7730 PMV. `geom_comfort_overlay()` draws filled
+PMV bands, `scale_fill_comfort_pmv()` applies a PMV-centered diverging palette,
+and `geom_comfort_pmv_lines()` adds labelled PMV curves.
+
+```{r pmv-overlay, fig.alt = "Psychrometric chart with filled PMV bands and labelled PMV curve lines."}
+ggpsychro(tdb_lim = c(5, 40), hum_lim = c(0, 24)) +
+    psychro_preset("minimal") +
+    geom_comfort_overlay(n = c(70, 48), gap = 0) +
+    scale_fill_comfort_pmv(name = "PMV") +
+    geom_comfort_pmv_lines(levels = seq(-3, 3, by = 0.5), n = 140)
+```
+
+## Standard comfort zones
+
+For PMV-based standards, `geom_comfort_standard_zone()` draws the filled zone,
+PMV boundary curves, and labels from a standard helper.
+
+```{r ashrae55-zone, fig.alt = "Psychrometric chart with the PMV-based ASHRAE 55 2017 comfort zone."}
+ggpsychro(tdb_lim = c(5, 35), hum_lim = c(0, 24)) +
+    psychro_preset("minimal") +
+    geom_comfort_standard_zone(comfort_standard_ashrae55_2017(), n = 140)
+```
+
+```{r en15251-zone, fig.alt = "Psychrometric chart with PMV-based EN 15251 2007 comfort bands."}
+ggpsychro(tdb_lim = c(5, 35), hum_lim = c(0, 24)) +
+    psychro_preset("minimal") +
+    geom_comfort_standard_zone(comfort_standard_en15251_2007(), n = 140)
+```
+
+## SET and adaptive models
+
+Create reusable model objects with `comfort_model_*()` helpers. SET overlays
+default to the `"set"` metric, while adaptive models default to
+`"acceptability"`.
+
+```{r set-overlay, fig.alt = "Psychrometric chart with a SET comfort overlay and labelled SET contour lines."}
+set_model <- comfort_model_set()
+
+ggpsychro(tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
+    psychro_preset("minimal") +
+    geom_comfort_overlay(model = set_model, n = c(40, 24)) +
+    geom_comfort_contour(
+        model = set_model,
+        metric = "set",
+        breaks = c(22, 24, 26),
+        n = c(40, 24),
+        colour = "#4A4A4A"
+    )
+```
+
+```{r adaptive-overlay, fig.alt = "Psychrometric chart with an adaptive comfort acceptability overlay and boundary zone."}
+adaptive_model <- comfort_model_adaptive(t_running = 20)
+
+ggpsychro(tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
+    psychro_preset("minimal") +
+    geom_comfort_overlay(model = adaptive_model, n = c(40, 24)) +
+    geom_comfort_zone(
+        model = adaptive_model,
+        fill = NA,
+        colour = "#4A4A4A"
+    )
+```
+
+## State metrics
+
+`stat_comfort_state()` evaluates the model at supplied psychrometric states.
+The computed comfort fields can be used with `after_stat()`.
+
+```{r state-metrics, fig.alt = "Psychrometric chart with measured state points coloured by computed PMV."}
+states <- data.frame(
+    tdb = c(22, 24, 26, 28),
+    relhum = c(45, 50, 55, 60)
+)
+
+ggpsychro(states, tdb_lim = c(15, 32), hum_lim = c(0, 22)) +
+    psychro_preset("minimal") +
+    stat_comfort_state(
+        aes(tdb = tdb, relhum = relhum, colour = after_stat(pmv)),
+        size = 3
+    ) +
+    scale_colour_gradient2(
+        "PMV",
+        low = "#3B5FFF",
+        mid = "#4A4A4A",
+        high = "#FF3B30",
+        midpoint = 0
+    )
+```
+
+## Mollier and IP charts
+
+Comfort layers follow the parent chart's coordinate system. Use
+`mollier = TRUE` for Mollier orientation or `units = "IP"` for IP inputs.
+
+```{r mollier-comfort-overlay, fig.alt = "Mollier psychrometric chart with a PMV comfort overlay and labelled PMV lines."}
+ggpsychro(tdb_lim = c(15, 30), hum_lim = c(0, 20), mollier = TRUE) +
+    psychro_preset("minimal") +
+    geom_comfort_overlay(n = c(50, 30)) +
+    scale_fill_comfort_pmv(name = "PMV") +
+    geom_comfort_pmv_lines(levels = seq(-2, 2, by = 1), n = 100)
+```
+
+Use manual psychrometric zones when the desired region is a project-specific
+operating envelope rather than a thermal comfort model. See [Zones and
+processes](zones-and-processes.html) for those layers.

--- a/vignettes/articles/grids-and-styles.Rmd
+++ b/vignettes/articles/grids-and-styles.Rmd
@@ -89,6 +89,37 @@ Line style arguments go directly to `ggplot2::element_line()`. Label style
 arguments use a `label.` prefix, such as `label.size`, `label.color`, and
 `label.vjust`.
 
+## Psychrometric protractor
+
+`geom_psychro_protractor()` adds the ASHRAE-style sensible heat ratio and
+heat-moisture-ratio protractor in the chart mask area. The parent chart decides
+the orientation: regular charts place it in the upper-left mask area, while
+Mollier charts rotate the same protractor into the lower-right mask area.
+
+```{r psychro-protractor, fig.width = 12, fig.height = 8, fig.alt = "ASHRAE-style psychrometric chart with a sensible heat ratio and heat-moisture-ratio protractor in the upper-left mask area."}
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    psychro_preset("ashrae") +
+    geom_psychro_protractor()
+```
+
+Use `scale` to resize the whole protractor and a length-2 `margin` to adjust
+the horizontal and vertical mask-area offsets. Tick breaks and labels are
+controlled by `guide_psychro_protractor()`.
+
+```{r psychro-protractor-custom, fig.width = 9, fig.height = 7, fig.alt = "Mollier chart with a smaller psychrometric protractor in the lower-right mask area and only sensible heat ratio labels shown."}
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30), mollier = TRUE) +
+    psychro_preset("minimal") +
+    geom_psychro_protractor(
+        scale = 0.85,
+        margin = c(0.06, 0.12),
+        guide = guide_psychro_protractor(
+            shr_breaks = c(0, 0.2, 0.4, 0.6, 0.8, 1),
+            shr_minor_breaks = seq(0.1, 0.9, by = 0.1),
+            ratio_labels = NULL
+        )
+    )
+```
+
 ## Theme elements
 
 ggpsychro adds psychrometric theme elements for panel masks and reference

--- a/vignettes/articles/plotting-data.Rmd
+++ b/vignettes/articles/plotting-data.Rmd
@@ -146,5 +146,6 @@ ggpsychro(weather, tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
     scale_fill_gradient("Mean cooling load", low = "#fef3c7", high = "#b45309")
 ```
 
-For state points, process lines, and comfort zones, see [Zones and
-processes](zones-and-processes.html).
+For model-based thermal comfort overlays, see [Comfort
+overlays](comfort-overlays.html). For manual state points, process lines, and
+zones, see [Zones and processes](zones-and-processes.html).

--- a/vignettes/articles/zones-and-processes.Rmd
+++ b/vignettes/articles/zones-and-processes.Rmd
@@ -18,6 +18,8 @@ knitr::opts_chunk$set(
 
 Use zones and process lines when a psychrometric chart needs to communicate
 constraints or movement between states, not just point observations.
+For model-based thermal comfort layers that calculate PMV, SET, or adaptive
+comfort across the chart, see [Comfort overlays](comfort-overlays.html).
 
 ## Comfort and operating zones
 


### PR DESCRIPTION
## Summary
Document the recently merged comfort overlays and psychrometric protractor, and restore missing NEWS bullets for recent user-facing changes.

## Changes
- Add a Comfort overlays pkgdown article covering PMV, PMV-based standard zones, SET/adaptive models, state metrics, and Mollier behavior.
- Add protractor guidance to the chart grids/styles article and link the new comfort article from README and related articles.
- Restore NEWS entries for #17, #18, #19, #20, and #21.