### PR TITLE
docs: refine comfort examples and acknowledgements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggpsychro 0.0.0.9000
 
+* Added README acknowledgements for external psychrometric-chart references and
+  refined SET/adaptive comfort overlay examples. (#23)
 * Added README and pkgdown documentation for comfort overlays and the
   psychrometric protractor. (#22)
 * Added an ASHRAE-style psychrometric protractor for sensible heat ratio and

--- a/README.Rmd
+++ b/README.Rmd
@@ -94,6 +94,22 @@ The longer examples live on the pkgdown site:
   draw manual comfort regions, operating limits, state points, and HVAC process
   lines.
 
+## Acknowledgements
+
+ggpsychro's recent chart-layout and higher-level layer work was informed by
+two excellent psychrometric chart projects:
+
+* [psychrochart](https://github.com/azogue/psychrochart), especially its
+  preset-oriented chart configuration, labelled reference grids, zone support,
+  and export-focused chart composition.
+* Andrew Marsh's [Psychrometric Chart](https://drajmarsh.bitbucket.io/psychro-chart2d.html),
+  especially its interactive psychrometric workflows, weather/data overlays,
+  comfort display ideas, and import/export-oriented chart interactions.
+
+ggpsychro does not vendor code from those projects. The implementation remains
+R/ggplot2-native, with psychrometric property calculations delegated to
+[PsychroLib](https://github.com/psychrometrics/psychrolib) where appropriate.
+
 ## Author
 
 Hongyuan Jia

--- a/README.md
+++ b/README.md
@@ -95,6 +95,25 @@ The longer examples live on the pkgdown site:
   draw manual comfort regions, operating limits, state points, and HVAC
   process lines.
 
+## Acknowledgements
+
+ggpsychro’s recent chart-layout and higher-level layer work was informed
+by two excellent psychrometric chart projects:
+
+- [psychrochart](https://github.com/azogue/psychrochart), especially its
+  preset-oriented chart configuration, labelled reference grids, zone
+  support, and export-focused chart composition.
+- Andrew Marsh’s [Psychrometric
+  Chart](https://drajmarsh.bitbucket.io/psychro-chart2d.html),
+  especially its interactive psychrometric workflows, weather/data
+  overlays, comfort display ideas, and import/export-oriented chart
+  interactions.
+
+ggpsychro does not vendor code from those projects. The implementation
+remains R/ggplot2-native, with psychrometric property calculations
+delegated to [PsychroLib](https://github.com/psychrometrics/psychrolib)
+where appropriate.
+
 ## Author
 
 Hongyuan Jia

--- a/vignettes/articles/comfort-overlays.Rmd
+++ b/vignettes/articles/comfort-overlays.Rmd
@@ -56,33 +56,36 @@ ggpsychro(tdb_lim = c(5, 35), hum_lim = c(0, 24)) +
 
 Create reusable model objects with `comfort_model_*()` helpers. SET overlays
 default to the `"set"` metric, while adaptive models default to
-`"acceptability"`.
+`"acceptability"`. For non-PMV metrics, contours and zones are often easier to
+read than a full-panel filled overlay because the metric can vary smoothly
+across almost the entire valid air region.
 
-```{r set-overlay, fig.alt = "Psychrometric chart with a SET comfort overlay and labelled SET contour lines."}
+```{r set-contours, fig.alt = "Psychrometric chart with SET contour lines."}
 set_model <- comfort_model_set()
 
 ggpsychro(tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
     psychro_preset("minimal") +
-    geom_comfort_overlay(model = set_model, n = c(40, 24)) +
     geom_comfort_contour(
         model = set_model,
         metric = "set",
-        breaks = c(22, 24, 26),
-        n = c(40, 24),
-        colour = "#4A4A4A"
+        breaks = seq(22, 30, by = 2),
+        n = c(70, 42),
+        colour = "#4A4A4A",
+        linewidth = 0.7
     )
 ```
 
-```{r adaptive-overlay, fig.alt = "Psychrometric chart with an adaptive comfort acceptability overlay and boundary zone."}
+```{r adaptive-zone, fig.alt = "Psychrometric chart with an adaptive comfort acceptability zone."}
 adaptive_model <- comfort_model_adaptive(t_running = 20)
 
 ggpsychro(tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
     psychro_preset("minimal") +
-    geom_comfort_overlay(model = adaptive_model, n = c(40, 24)) +
     geom_comfort_zone(
         model = adaptive_model,
-        fill = NA,
-        colour = "#4A4A4A"
+        fill = "#22c55e",
+        alpha = 0.18,
+        colour = "#166534",
+        linewidth = 0.7
     )
 ```
 


### PR DESCRIPTION
## Summary
Refine the comfort overlay docs so SET and adaptive examples use clearer visual encodings, and add README acknowledgements for major external psychrometric-chart references.

## Changes
- Replace the filled SET/adaptive example with SET contours and an adaptive comfort zone to avoid visually heavy full-panel overlays.
- Add README acknowledgements for psychrochart and Andrew Marsh's Psychrometric Chart, while clarifying that ggpsychro does not vendor their code.
- Regenerate README.md from README.Rmd.