### PR TITLE
docs: clarify set and adaptive comfort examples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggpsychro 0.0.0.9000
 
+* Clarified SET and adaptive comfort overlay examples in the comfort overlays
+  article. (#25)
 * Added README acknowledgements for external psychrometric-chart references and
   refined SET/adaptive comfort overlay examples. (#23)
 * Added README and pkgdown documentation for comfort overlays and the

--- a/vignettes/articles/comfort-overlays.Rmd
+++ b/vignettes/articles/comfort-overlays.Rmd
@@ -56,21 +56,28 @@ ggpsychro(tdb_lim = c(5, 35), hum_lim = c(0, 24)) +
 
 Create reusable model objects with `comfort_model_*()` helpers. SET overlays
 default to the `"set"` metric, while adaptive models default to
-`"acceptability"`. For non-PMV metrics, contours and zones are often easier to
-read than a full-panel filled overlay because the metric can vary smoothly
-across almost the entire valid air region.
+`"acceptability"`. For continuous metrics such as SET, use filled bands with
+contours so the field remains visible without losing the level boundaries.
 
-```{r set-contours, fig.alt = "Psychrometric chart with SET contour lines."}
+```{r set-overlay, fig.alt = "Psychrometric chart with filled SET bands and SET contour lines."}
 set_model <- comfort_model_set()
 
 ggpsychro(tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
     psychro_preset("minimal") +
+    geom_comfort_overlay(
+        model = set_model,
+        metric = "set",
+        levels = seq(14, 32, by = 2),
+        n = c(70, 42),
+        alpha = 0.32
+    ) +
+    scale_fill_viridis_c("SET (deg C)", option = "C") +
     geom_comfort_contour(
         model = set_model,
         metric = "set",
-        breaks = seq(22, 30, by = 2),
+        breaks = seq(18, 30, by = 2),
         n = c(70, 42),
-        colour = "#4A4A4A",
+        colour = "#2F2F2F",
         linewidth = 0.7
     )
 ```
@@ -88,6 +95,11 @@ ggpsychro(tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
         linewidth = 0.7
     )
 ```
+
+Adaptive comfort zones are temperature bands rather than humidity-dependent
+fields. In the example above, `t_running = 20` gives an ASHRAE 55 80%
+acceptability interval from 20.5 to 27.5 degrees C; because `tr` defaults to
+`tdb`, the zone appears as a vertical band clipped to the current chart limits.
 
 ## State metrics
 


### PR DESCRIPTION
## Summary
Clarify why the SET and adaptive comfort examples look different from PMV overlays, and update the SET example to use both filled bands and contour boundaries.

## Changes
- Change the SET documentation example to show filled SET bands plus contour boundaries and a SET colorbar.
- Explain that adaptive comfort zones are temperature bands, so they appear as vertical dry-bulb intervals on a psychrometric chart.
- Validate the updated comfort overlay article locally.