### PR TITLE
docs: expand reference examples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggpsychro 0.0.0.9000
 
+* Added runnable reference examples across exported documentation topics and
+  grouped pkgdown reference pages by workflow area. (#29)
 * Preserved ordinary ggplot2 aesthetics across legacy psychrometric stats.
   (#27)
 * Replaced foreground psychrometric panel masking with valid-region clipping for

--- a/R/comfort.R
+++ b/R/comfort.R
@@ -210,6 +210,50 @@ comfort_heat_index <- function(tdb, rh, solar_exposure = 0,
 #'   unrounded values by default so contours and zones remain smooth.
 #'
 #' @return A comfort model object.
+#'
+#' @examples
+#' # Create a PMV model object.
+#' comfort_model_pmv(met = 1.4, clo = 0.5)
+#'
+#' # Create a SET model object.
+#' comfort_model_set(v = 0.2)
+#'
+#' # Create an adaptive comfort model object.
+#' comfort_model_adaptive(t_running = 22)
+#'
+#' # Create a heat-index model object.
+#' comfort_model_heat_index(solar_exposure = 0.5)
+#'
+#' # Draw a PMV overlay using custom activity and clothing assumptions.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_overlay(
+#'         model = comfort_model_pmv(met = 1.4, clo = 0.5),
+#'         n = c(45, 30)
+#'     )
+#'
+#' # Draw SET as the filled comfort metric.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_overlay(
+#'         model = comfort_model_set(v = 0.2),
+#'         metric = "set",
+#'         n = c(45, 30)
+#'     )
+#'
+#' # Draw the adaptive acceptability region.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_zone(
+#'         model = comfort_model_adaptive(t_running = 22),
+#'         metric = "acceptability",
+#'         n = c(45, 30),
+#'         alpha = 0.3
+#'     )
+#'
+#' # Draw heat-index categories with a solar exposure adjustment.
+#' ggpsychro(tdb_lim = c(25, 45), hum_lim = c(0, 32)) +
+#'     geom_comfort_heat_index(
+#'         model = comfort_model_heat_index(solar_exposure = 0.5),
+#'         n = c(55, 35)
+#'     )
 #' @export
 comfort_model_pmv <- function(tr = NULL, vr = 0.1, met = 1.2, clo = 0.5,
                               wme = 0, model = "7730-2005",
@@ -286,6 +330,27 @@ comfort_model_heat_index <- function(solar_exposure = 0,
 #'
 #' @return A comfort standard object.
 #'
+#' @examples
+#' # Create the ASHRAE 55 PMV comfort interval.
+#' comfort_standard_ashrae55_2017()
+#'
+#' # Create the EN 15251 PMV comfort bands.
+#' comfort_standard_en15251_2007()
+#'
+#' # Draw the ASHRAE 55 comfort zone.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_standard_zone(
+#'         standard = comfort_standard_ashrae55_2017(),
+#'         n = 80
+#'     )
+#'
+#' # Draw the EN 15251 comfort bands.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_standard_zone(
+#'         standard = comfort_standard_en15251_2007(),
+#'         n = 80
+#'     )
+#'
 #' @export
 comfort_standard_ashrae55_2017 <- function(range = c(-0.5, 0.5)) {
     range <- comfort_check_breaks(range, "`range`", n_min = 2L)
@@ -328,6 +393,17 @@ comfort_standard_en15251_2007 <- function(breaks = c(-0.7, -0.2, 0.2, 0.7)) {
 #'
 #' @return A Givoni comfort strategy object.
 #'
+#' @examples
+#' # Create a Givoni strategy for a warm outdoor mean.
+#' comfort_strategy_givoni(mean_outdoor = 22)
+#'
+#' # Draw the Givoni strategy overlay for that outdoor mean.
+#' ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+#'     geom_comfort_givoni(
+#'         strategy = comfort_strategy_givoni(mean_outdoor = 22),
+#'         show_labels = FALSE
+#'     )
+#'
 #' @export
 comfort_strategy_givoni <- function(mean_outdoor = 19,
                                     units = c("SI", "IP")) {
@@ -353,6 +429,47 @@ comfort_strategy_givoni <- function(mean_outdoor = 19,
 #'   properties. Values left as [ggplot2::waiver()] inherit the layer default.
 #'
 #' @return A comfort zone style element.
+#'
+#' @examples
+#' # Fill and outline the comfort zone with custom colours.
+#' ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+#'     geom_comfort_givoni(
+#'         show_labels = FALSE,
+#'         zone_style = list(
+#'             comfort = element_comfort_zone(
+#'                 fill = "#6FCF97",
+#'                 colour = "#1B7F4A",
+#'                 alpha = 0.35
+#'             )
+#'         )
+#'     )
+#'
+#' # Emphasize the air-conditioning region with a light fill.
+#' ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+#'     geom_comfort_givoni(
+#'         show_labels = FALSE,
+#'         zone_style = list(
+#'             air_conditioning = element_comfort_zone(
+#'                 fill = "#7BC8F6",
+#'                 colour = "#1B5E8C",
+#'                 alpha = 0.18,
+#'                 linetype = "solid"
+#'             )
+#'         )
+#'     )
+#'
+#' # Restyle a line-only region without filling it.
+#' ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+#'     geom_comfort_givoni(
+#'         show_labels = FALSE,
+#'         zone_style = list(
+#'             winter = element_comfort_zone(
+#'                 colour = "#C44536",
+#'                 linewidth = 1.2,
+#'                 linetype = "dashed"
+#'             )
+#'         )
+#'     )
 #'
 #' @export
 element_comfort_zone <- function(fill = ggplot2::waiver(),
@@ -427,6 +544,58 @@ element_comfort_zone <- function(fill = ggplot2::waiver(),
 #'   with [element_comfort_zone()], [ggplot2::element_polygon()], or ordinary
 #'   named lists with fields `fill`, `colour`/`color`, `linewidth`, `linetype`,
 #'   `alpha`, and `linejoin`.
+#'
+#' @examples
+#' # Draw filled PMV comfort bands.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_overlay(n = c(45, 30)) +
+#'     scale_fill_comfort_pmv(name = "PMV")
+#'
+#' # Draw labelled PMV contour lines.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_contour(
+#'         breaks = c(-1, 0, 1),
+#'         label = TRUE,
+#'         n = 80
+#'     )
+#'
+#' # Draw the neutral PMV comfort zone.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_zone(
+#'         range = c(-0.5, 0.5),
+#'         n = c(45, 30),
+#'         alpha = 0.3
+#'     )
+#'
+#' # Draw PMV curves and thermal sensation labels.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_pmv_lines(levels = seq(-2, 2, by = 1), n = 100)
+#'
+#' # Draw a PMV-based comfort standard zone.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_standard_zone(
+#'         standard = comfort_standard_ashrae55_2017(),
+#'         n = 80
+#'     )
+#'
+#' # Draw heat-index categories on hot conditions.
+#' ggpsychro(tdb_lim = c(25, 45), hum_lim = c(0, 32)) +
+#'     geom_comfort_heat_index(n = c(55, 35), show_labels = FALSE)
+#'
+#' # Draw Givoni bioclimatic strategy zones.
+#' ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+#'     geom_comfort_givoni(show_labels = FALSE)
+#'
+#' # Evaluate PMV at supplied state points.
+#' states <- data.frame(
+#'     tdb = c(24, 28, 31),
+#'     relhum = c(45, 55, 65)
+#' )
+#' ggpsychro(states, tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     stat_comfort_state(
+#'         aes(tdb = tdb, relhum = relhum, colour = after_stat(pmv)),
+#'         size = 3
+#'     )
 #'
 #' @export
 geom_comfort_overlay <- function(mapping = NULL, data = NULL,
@@ -1056,6 +1225,27 @@ stat_comfort_state <- function(mapping = NULL, data = NULL, geom = "point",
 #' @param low,mid,high Endpoint and midpoint colours.
 #' @param midpoint Scale midpoint.
 #' @param oob Out-of-bounds handler.
+#'
+#' @examples
+#' # Use the default PMV colour scale.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_overlay(n = c(45, 30)) +
+#'     scale_fill_comfort_pmv(name = "PMV")
+#'
+#' # Focus the legend on the usual comfort range.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_overlay(n = c(45, 30)) +
+#'     scale_fill_comfort_pmv(limits = c(-1.5, 1.5), name = "PMV")
+#'
+#' # Use a custom diverging palette.
+#' ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+#'     geom_comfort_overlay(n = c(45, 30)) +
+#'     scale_fill_comfort_pmv(
+#'         low = "#2166AC",
+#'         mid = "white",
+#'         high = "#B2182B",
+#'         name = "PMV"
+#'     )
 #'
 #' @export
 scale_fill_comfort_pmv <- function(..., limits = c(-3, 3),

--- a/R/ggpsychro.R
+++ b/R/ggpsychro.R
@@ -94,6 +94,11 @@ ggpsychro <- function (data = NULL, mapping = aes(), tdb_lim = NULL, hum_lim = N
 
 #' Reports whether x is a ggplot object
 #' @param x An object to test
+#'
+#' @examples
+#' is.ggpsychro(ggpsychro())
+#' is.ggpsychro(ggplot2::ggplot())
+#'
 #' @keywords internal
 #' @export
 is.ggpsychro <- function (x) {

--- a/R/grid-layer.R
+++ b/R/grid-layer.R
@@ -123,11 +123,39 @@ geom_grid_enthalpy <- function(..., show = TRUE, label = TRUE, label_loc = 0.95,
 #' @export
 #'
 #' @examples
+#' # Draw the default protractor on a psychrometric chart.
 #' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
 #'     geom_psychro_protractor()
 #'
+#' # Draw the protractor in Mollier orientation.
 #' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30), mollier = TRUE) +
 #'     geom_psychro_protractor()
+#'
+#' # Customize major tick breaks with a guide.
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     geom_psychro_protractor(
+#'         guide = guide_psychro_protractor(
+#'             shr_breaks = seq(0, 1, by = 0.25),
+#'             ratio_breaks = c(0, 2000, 4000)
+#'         )
+#'     )
+#'
+#' # Hide the helper formula annotations.
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     geom_psychro_protractor(annotation = FALSE)
+#'
+#' # Scale and move the protractor inside the mask area.
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     geom_psychro_protractor(scale = 1.2, margin = c(0.03, 0.10))
+#'
+#' # Supply custom labels for selected sensible heat ratio ticks.
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     geom_psychro_protractor(
+#'         guide = guide_psychro_protractor(
+#'             shr_breaks = c(0, 0.5, 1),
+#'             shr_labels = c("0", "half", "1")
+#'         )
+#'     )
 geom_psychro_protractor <- function(..., show = TRUE, label = TRUE, annotation = TRUE,
                                     scale = 1, radius = 0.24, margin = 0.08,
                                     guide = guide_psychro_protractor()) {

--- a/R/labels.R
+++ b/R/labels.R
@@ -47,6 +47,14 @@ default_labs <- function(units = "SI", mollier = FALSE) {
 #' demo_scale(seq(1000, 2000), labels = label_enthalpy(units = "SI", parse = TRUE))
 #' demo_scale(seq(1000, 2000), labels = label_enthalpy(units = "IP", parse = TRUE))
 #'
+#' demo_scale(10:50, labels = drybulb_format(units = "SI", parse = TRUE))
+#' demo_scale(10:20, labels = humratio_format(scale = 0.001, units = "SI", parse = TRUE))
+#' demo_scale(10:50, labels = relhum_format(units = "SI"))
+#' demo_scale(10:50, labels = wetbulb_format(units = "SI", parse = TRUE))
+#' demo_scale(10:50, labels = specvol_format(units = "SI", parse = TRUE))
+#' demo_scale(10:50, labels = vappres_format(units = "SI"))
+#' demo_scale(seq(1000, 2000), labels = enthalpy_format(units = "SI", parse = TRUE))
+#'
 #' @rdname label
 #' @export
 label_drybulb <- function(x, accuracy = NULL, scale = 1, units,
@@ -217,6 +225,9 @@ force_all <- function (...) list(...)
 #'
 #' @param x A vector of data
 #' @param ... Other arguments pass to scale functions
+#'
+#' @examples
+#' demo_scale(0:10, labels = scales::label_number())
 #'
 #' @keywords internal
 #' @export

--- a/R/psychro-zone.R
+++ b/R/psychro-zone.R
@@ -90,6 +90,15 @@ NULL
 #'         type = "xy-points",
 #'         alpha = 0.25
 #'     )
+#'
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     stat_psychro_zone(
+#'         aes(tdb = tdb, humratio = humratio),
+#'         data = polygon_zone,
+#'         type = "xy-points",
+#'         geom = "polygon",
+#'         alpha = 0.25
+#'     )
 #' @export
 geom_psychro_zone <- function(mapping = NULL, data = NULL, stat = "psychro_zone",
                               position = "identity", ..., type = "dbt-rh",

--- a/R/scale.R
+++ b/R/scale.R
@@ -6,16 +6,41 @@ NULL
 #' @inheritParams ggplot2::continuous_scale
 #' @inheritParams ggplot2::scale_x_continuous
 #'
-#' @param trans TODO: determined by `units`
+#' @param trans,transform A transformation object or transformer name passed
+#'   to the underlying ggplot2 continuous scale. The default [ggplot2::waiver()]
+#'   keeps the psychrometric scale in chart display units.
 #'
 #' @rdname scale
 #' @importFrom ggplot2 continuous_scale
 #' @export
 #' @examples
-#' ggpsychro(tdb_lim = c(0, 35), hum_lim = c(0, 50)) +
+#' # Configure dry-bulb and humidity-ratio axes.
+#' ggpsychro(tdb_lim = c(0, 35), hum_lim = c(0, 25)) +
+#'     scale_drybulb_continuous(breaks = seq(0, 35, by = 5)) +
+#'     scale_humratio_continuous(breaks = seq(0, 25, by = 5))
+#'
+#' # Configure relative-humidity and wet-bulb grid breaks.
+#' ggpsychro(tdb_lim = c(0, 35), hum_lim = c(0, 25)) +
 #'     scale_relhum_continuous(n.breaks = 8) +
-#'     scale_wetbulb_continuous(breaks = seq(25, 30, by = 5), minor_breaks = NULL) +
-#'     scale_vappres_continuous(breaks = seq(6000, 7000, by = 500), limits = c(6000, 7000))
+#'     scale_wetbulb_continuous(
+#'         breaks = seq(10, 30, by = 5),
+#'         minor_breaks = NULL
+#'     )
+#'
+#' # Configure vapor-pressure, specific-volume, and enthalpy grids.
+#' ggpsychro(tdb_lim = c(0, 35), hum_lim = c(0, 25)) +
+#'     scale_vappres_continuous(
+#'         breaks = seq(1000, 4000, by = 1000),
+#'         limits = c(1000, 4500)
+#'     ) +
+#'     scale_specvol_continuous(
+#'         breaks = seq(0.80, 0.95, by = 0.05),
+#'         limits = c(0.80, 0.95)
+#'     ) +
+#'     scale_enthalpy_continuous(
+#'         breaks = seq(20000, 80000, by = 20000),
+#'         limits = c(20000, 80000)
+#'     )
 #'
 scale_drybulb_continuous <- function(name = waiver(), breaks = waiver(), minor_breaks = waiver(),
                                      n.breaks = NULL, labels = waiver(), limits = NULL,

--- a/R/stat-psychro-bin.R
+++ b/R/stat-psychro-bin.R
@@ -72,6 +72,12 @@ NULL
 #'     )
 #'
 #' ggpsychro(d, tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
+#'     stat_psychro_bin(
+#'         aes(dry_bulb, relhum = relative_humidity, fill = after_stat(hours)),
+#'         binwidth = c(2, 2)
+#'     )
+#'
+#' ggpsychro(d, tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
 #'     geom_psychro_tile(
 #'         aes(dry_bulb, relhum = relative_humidity, value = cooling_load,
 #'             fill = after_stat(value)),

--- a/R/stat.R
+++ b/R/stat.R
@@ -46,8 +46,13 @@ NULL
 #' ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
 #'     stat_relhum(aes(x = tdb, relhum = relhum), data = states)
 #'
-#' # The stats can also be used from ordinary ggplot2 geoms.
 #' wetbulb_line <- data.frame(tdb = 18:30, wetbulb = 16)
+#' ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+#'     geom_grid_wetbulb() +
+#'     stat_wetbulb(aes(x = tdb, wetbulb = wetbulb),
+#'         data = wetbulb_line, geom = "line")
+#'
+#' # The stats can also be used from ordinary ggplot2 geoms.
 #' ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
 #'     geom_grid_wetbulb() +
 #'     geom_line(aes(x = tdb, wetbulb = wetbulb),

--- a/R/theme-elements.R
+++ b/R/theme-elements.R
@@ -10,6 +10,17 @@
 #' @param inherit.blank Whether this element inherits from blank elements.
 #'
 #' @return A ggplot2 theme element.
+#'
+#' @examples
+#' ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+#'     ggplot2::theme(
+#'         psychro.panel.background = element_polygon(
+#'             fill = "#F7F7F2",
+#'             colour = "grey60",
+#'             size = 0.4
+#'         )
+#'     )
+#'
 #' @export
 element_polygon <- function(fill = NULL, colour = NULL, size = NULL, linetype = NULL,
                             color = NULL, inherit.blank = FALSE) {

--- a/R/theme.R
+++ b/R/theme.R
@@ -13,9 +13,20 @@
 #' @author Hongyuan Jia
 #' @importFrom ggplot2 "%+replace%"
 #' @examples
-#' theme_psychro()
-#' theme_psychro_ashrae()
-#' theme_psychro_minimal()
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     theme_grey_psychro()
+#'
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     theme_gray_psychro()
+#'
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     theme_psychro()
+#'
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     theme_psychro_ashrae()
+#'
+#' ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+#'     theme_psychro_minimal()
 #'
 #' @name theme
 #' @export

--- a/R/trans.R
+++ b/R/trans.R
@@ -25,6 +25,7 @@ is.empty_trans <- function(trans) {
 #' plot(wetbulb_trans("SI"), xlim = c(-50, 40))
 #' plot(vappres_trans("SI"), xlim = c(1000, 4000))
 #' plot(specvol_trans("SI"), xlim = c(0.8, 1))
+#' plot(enthalpy_trans("SI"), xlim = c(1000, 2000))
 drybulb_trans <- function(units = "SI") {
     units <- match.arg(units, c("SI", "IP"))
     trans_new("drybulb", "force", "force",

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,6 +4,60 @@ destination: docs
 template:
   bootstrap: 5
 
+reference:
+- title: Package overview
+  contents:
+  - ggpsychro-package
+
+- title: Core chart construction
+  contents:
+  - ggpsychro
+  - coord_psychro
+  - is.ggpsychro
+
+- title: Psychrometric equation layers and grids
+  contents:
+  - stat_relhum
+  - geom_grid_relhum
+  - geom_psychro_protractor
+
+- title: Psychrometric data layers
+  contents:
+  - geom_psychro_process
+  - geom_psychro_zone
+  - stat_psychro_bin
+
+- title: Thermal comfort calculations and models
+  contents:
+  - comfort_pmv
+  - comfort_model_pmv
+  - comfort_standard_ashrae55_2017
+  - comfort_strategy_givoni
+
+- title: Thermal comfort chart layers
+  contents:
+  - geom_comfort_overlay
+  - scale_fill_comfort_pmv
+
+- title: Scales, labels, and transformations
+  contents:
+  - scale_drybulb_continuous
+  - label_drybulb
+  - drybulb_trans
+  - demo_scale
+
+- title: Themes, presets, and elements
+  contents:
+  - theme
+  - psychro_preset
+  - element_polygon
+  - element_comfort_zone
+
+- title: Extension API
+  contents:
+  - ggpsychro-extensions
+  - ggpsychro-ggproto
+
 articles:
 - title: Start
   navbar:

--- a/man/comfort_model_pmv.Rd
+++ b/man/comfort_model_pmv.Rd
@@ -89,3 +89,47 @@ A comfort model object.
 Model objects capture the fixed inputs used by comfort layers. They can be
 reused across overlays, contours, zones, and point states.
 }
+\examples{
+# Create a PMV model object.
+comfort_model_pmv(met = 1.4, clo = 0.5)
+
+# Create a SET model object.
+comfort_model_set(v = 0.2)
+
+# Create an adaptive comfort model object.
+comfort_model_adaptive(t_running = 22)
+
+# Create a heat-index model object.
+comfort_model_heat_index(solar_exposure = 0.5)
+
+# Draw a PMV overlay using custom activity and clothing assumptions.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_overlay(
+        model = comfort_model_pmv(met = 1.4, clo = 0.5),
+        n = c(45, 30)
+    )
+
+# Draw SET as the filled comfort metric.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_overlay(
+        model = comfort_model_set(v = 0.2),
+        metric = "set",
+        n = c(45, 30)
+    )
+
+# Draw the adaptive acceptability region.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_zone(
+        model = comfort_model_adaptive(t_running = 22),
+        metric = "acceptability",
+        n = c(45, 30),
+        alpha = 0.3
+    )
+
+# Draw heat-index categories with a solar exposure adjustment.
+ggpsychro(tdb_lim = c(25, 45), hum_lim = c(0, 32)) +
+    geom_comfort_heat_index(
+        model = comfort_model_heat_index(solar_exposure = 0.5),
+        n = c(55, 35)
+    )
+}

--- a/man/comfort_standard_ashrae55_2017.Rd
+++ b/man/comfort_standard_ashrae55_2017.Rd
@@ -22,3 +22,25 @@ These helpers describe static PMV-based comfort zones. They are distinct from
 adaptive comfort models such as \code{\link[=comfort_model_adaptive]{comfort_model_adaptive()}}, which use running
 mean outdoor temperature and produce operative-temperature bands.
 }
+\examples{
+# Create the ASHRAE 55 PMV comfort interval.
+comfort_standard_ashrae55_2017()
+
+# Create the EN 15251 PMV comfort bands.
+comfort_standard_en15251_2007()
+
+# Draw the ASHRAE 55 comfort zone.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_standard_zone(
+        standard = comfort_standard_ashrae55_2017(),
+        n = 80
+    )
+
+# Draw the EN 15251 comfort bands.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_standard_zone(
+        standard = comfort_standard_en15251_2007(),
+        n = 80
+    )
+
+}

--- a/man/comfort_strategy_givoni.Rd
+++ b/man/comfort_strategy_givoni.Rd
@@ -21,3 +21,15 @@ Bioclimatic Chart overlay: the mean outdoor temperature shifts the base
 comfort zone, and zones are drawn in dry-bulb/relative-humidity space before
 conversion to humidity ratio.
 }
+\examples{
+# Create a Givoni strategy for a warm outdoor mean.
+comfort_strategy_givoni(mean_outdoor = 22)
+
+# Draw the Givoni strategy overlay for that outdoor mean.
+ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+    geom_comfort_givoni(
+        strategy = comfort_strategy_givoni(mean_outdoor = 22),
+        show_labels = FALSE
+    )
+
+}

--- a/man/demo_scale.Rd
+++ b/man/demo_scale.Rd
@@ -15,4 +15,8 @@ demo_scale(x, ...)
 This function generates ggplot2 code needed to use scales functions for real
 code.
 }
+\examples{
+demo_scale(0:10, labels = scales::label_number())
+
+}
 \keyword{internal}

--- a/man/element_comfort_zone.Rd
+++ b/man/element_comfort_zone.Rd
@@ -26,3 +26,45 @@ A comfort zone style element.
 zones. It is used by \code{geom_comfort_givoni()} through the \code{zone_style}
 argument to override Marsh-style defaults for individual zones.
 }
+\examples{
+# Fill and outline the comfort zone with custom colours.
+ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+    geom_comfort_givoni(
+        show_labels = FALSE,
+        zone_style = list(
+            comfort = element_comfort_zone(
+                fill = "#6FCF97",
+                colour = "#1B7F4A",
+                alpha = 0.35
+            )
+        )
+    )
+
+# Emphasize the air-conditioning region with a light fill.
+ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+    geom_comfort_givoni(
+        show_labels = FALSE,
+        zone_style = list(
+            air_conditioning = element_comfort_zone(
+                fill = "#7BC8F6",
+                colour = "#1B5E8C",
+                alpha = 0.18,
+                linetype = "solid"
+            )
+        )
+    )
+
+# Restyle a line-only region without filling it.
+ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+    geom_comfort_givoni(
+        show_labels = FALSE,
+        zone_style = list(
+            winter = element_comfort_zone(
+                colour = "#C44536",
+                linewidth = 1.2,
+                linetype = "dashed"
+            )
+        )
+    )
+
+}

--- a/man/element_polygon.Rd
+++ b/man/element_polygon.Rd
@@ -31,3 +31,14 @@ A ggplot2 theme element.
 \code{element_polygon()} is used by ggpsychro-specific theme elements such as
 \code{psychro.panel.background} and \code{psychro.panel.mask}.
 }
+\examples{
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    ggplot2::theme(
+        psychro.panel.background = element_polygon(
+            fill = "#F7F7F2",
+            colour = "grey60",
+            size = 0.4
+        )
+    )
+
+}

--- a/man/geom_comfort_overlay.Rd
+++ b/man/geom_comfort_overlay.Rd
@@ -327,3 +327,56 @@ default, and uses the same grid as the overlay for other metrics.
 \code{geom_comfort_zone()} draws a comfort region, and \code{stat_comfort_state()}
 evaluates comfort fields at supplied states.
 }
+\examples{
+# Draw filled PMV comfort bands.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_overlay(n = c(45, 30)) +
+    scale_fill_comfort_pmv(name = "PMV")
+
+# Draw labelled PMV contour lines.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_contour(
+        breaks = c(-1, 0, 1),
+        label = TRUE,
+        n = 80
+    )
+
+# Draw the neutral PMV comfort zone.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_zone(
+        range = c(-0.5, 0.5),
+        n = c(45, 30),
+        alpha = 0.3
+    )
+
+# Draw PMV curves and thermal sensation labels.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_pmv_lines(levels = seq(-2, 2, by = 1), n = 100)
+
+# Draw a PMV-based comfort standard zone.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_standard_zone(
+        standard = comfort_standard_ashrae55_2017(),
+        n = 80
+    )
+
+# Draw heat-index categories on hot conditions.
+ggpsychro(tdb_lim = c(25, 45), hum_lim = c(0, 32)) +
+    geom_comfort_heat_index(n = c(55, 35), show_labels = FALSE)
+
+# Draw Givoni bioclimatic strategy zones.
+ggpsychro(tdb_lim = c(5, 45), hum_lim = c(0, 30)) +
+    geom_comfort_givoni(show_labels = FALSE)
+
+# Evaluate PMV at supplied state points.
+states <- data.frame(
+    tdb = c(24, 28, 31),
+    relhum = c(45, 55, 65)
+)
+ggpsychro(states, tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    stat_comfort_state(
+        aes(tdb = tdb, relhum = relhum, colour = after_stat(pmv)),
+        size = 3
+    )
+
+}

--- a/man/geom_psychro_protractor.Rd
+++ b/man/geom_psychro_protractor.Rd
@@ -83,9 +83,37 @@ the same protractor geometry into the lower-right mask area.
 \code{guide_psychro_protractor()} configures the protractor ticks and labels.
 }
 \examples{
+# Draw the default protractor on a psychrometric chart.
 ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
     geom_psychro_protractor()
 
+# Draw the protractor in Mollier orientation.
 ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30), mollier = TRUE) +
     geom_psychro_protractor()
+
+# Customize major tick breaks with a guide.
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    geom_psychro_protractor(
+        guide = guide_psychro_protractor(
+            shr_breaks = seq(0, 1, by = 0.25),
+            ratio_breaks = c(0, 2000, 4000)
+        )
+    )
+
+# Hide the helper formula annotations.
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    geom_psychro_protractor(annotation = FALSE)
+
+# Scale and move the protractor inside the mask area.
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    geom_psychro_protractor(scale = 1.2, margin = c(0.03, 0.10))
+
+# Supply custom labels for selected sensible heat ratio ticks.
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    geom_psychro_protractor(
+        guide = guide_psychro_protractor(
+            shr_breaks = c(0, 0.5, 1),
+            shr_labels = c("0", "half", "1")
+        )
+    )
 }

--- a/man/is.ggpsychro.Rd
+++ b/man/is.ggpsychro.Rd
@@ -12,4 +12,9 @@ is.ggpsychro(x)
 \description{
 Reports whether x is a ggplot object
 }
+\examples{
+is.ggpsychro(ggpsychro())
+is.ggpsychro(ggplot2::ggplot())
+
+}
 \keyword{internal}

--- a/man/label.Rd
+++ b/man/label.Rd
@@ -243,4 +243,12 @@ demo_scale(10:50, labels = label_vappres(units = "IP"))
 demo_scale(seq(1000, 2000), labels = label_enthalpy(units = "SI", parse = TRUE))
 demo_scale(seq(1000, 2000), labels = label_enthalpy(units = "IP", parse = TRUE))
 
+demo_scale(10:50, labels = drybulb_format(units = "SI", parse = TRUE))
+demo_scale(10:20, labels = humratio_format(scale = 0.001, units = "SI", parse = TRUE))
+demo_scale(10:50, labels = relhum_format(units = "SI"))
+demo_scale(10:50, labels = wetbulb_format(units = "SI", parse = TRUE))
+demo_scale(10:50, labels = specvol_format(units = "SI", parse = TRUE))
+demo_scale(10:50, labels = vappres_format(units = "SI"))
+demo_scale(seq(1000, 2000), labels = enthalpy_format(units = "SI", parse = TRUE))
+
 }

--- a/man/psychro_zone.Rd
+++ b/man/psychro_zone.Rd
@@ -222,4 +222,13 @@ ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
         type = "xy-points",
         alpha = 0.25
     )
+
+ggpsychro(tdb_lim = c(0, 40), hum_lim = c(0, 25)) +
+    stat_psychro_zone(
+        aes(tdb = tdb, humratio = humratio),
+        data = polygon_zone,
+        type = "xy-points",
+        geom = "polygon",
+        alpha = 0.25
+    )
 }

--- a/man/scale.Rd
+++ b/man/scale.Rd
@@ -177,20 +177,9 @@ to generate the values for the \code{expand} argument. The defaults are to
 expand the scale by 5\% on each side for continuous variables, and by
 0.6 units on each side for discrete variables.}
 
-\item{trans}{TODO: determined by \code{units}}
-
-\item{transform}{For continuous scales, the name of a transformation object
-or the object itself. Built-in transformations include "asn", "atanh",
-"boxcox", "date", "exp", "hms", "identity", "log", "log10", "log1p", "log2",
-"logit", "modulus", "probability", "probit", "pseudo_log", "reciprocal",
-"reverse", "sqrt" and "time".
-
-A transformation object bundles together a transform, its inverse,
-and methods for generating breaks and labels. Transformation objects
-are defined in the scales package, and are called \verb{transform_<name>}. If
-transformations require arguments, you can call them from the scales
-package, e.g. \code{\link[scales:transform_boxcox]{scales::transform_boxcox(p = 2)}}.
-You can create your own transformation with \code{\link[scales:new_transform]{scales::new_transform()}}.}
+\item{trans, transform}{A transformation object or transformer name passed
+to the underlying ggplot2 continuous scale. The default \code{\link[ggplot2:waiver]{ggplot2::waiver()}}
+keeps the psychrometric scale in chart display units.}
 
 \item{guide}{A function used to create a guide or its name. See
 \code{\link[ggplot2:guides]{guides()}} for more information.}
@@ -201,9 +190,32 @@ You can create your own transformation with \code{\link[scales:new_transform]{sc
 Transformation object for psychrometric chart
 }
 \examples{
-ggpsychro(tdb_lim = c(0, 35), hum_lim = c(0, 50)) +
+# Configure dry-bulb and humidity-ratio axes.
+ggpsychro(tdb_lim = c(0, 35), hum_lim = c(0, 25)) +
+    scale_drybulb_continuous(breaks = seq(0, 35, by = 5)) +
+    scale_humratio_continuous(breaks = seq(0, 25, by = 5))
+
+# Configure relative-humidity and wet-bulb grid breaks.
+ggpsychro(tdb_lim = c(0, 35), hum_lim = c(0, 25)) +
     scale_relhum_continuous(n.breaks = 8) +
-    scale_wetbulb_continuous(breaks = seq(25, 30, by = 5), minor_breaks = NULL) +
-    scale_vappres_continuous(breaks = seq(6000, 7000, by = 500), limits = c(6000, 7000))
+    scale_wetbulb_continuous(
+        breaks = seq(10, 30, by = 5),
+        minor_breaks = NULL
+    )
+
+# Configure vapor-pressure, specific-volume, and enthalpy grids.
+ggpsychro(tdb_lim = c(0, 35), hum_lim = c(0, 25)) +
+    scale_vappres_continuous(
+        breaks = seq(1000, 4000, by = 1000),
+        limits = c(1000, 4500)
+    ) +
+    scale_specvol_continuous(
+        breaks = seq(0.80, 0.95, by = 0.05),
+        limits = c(0.80, 0.95)
+    ) +
+    scale_enthalpy_continuous(
+        breaks = seq(20000, 80000, by = 20000),
+        limits = c(20000, 80000)
+    )
 
 }

--- a/man/scale_fill_comfort_pmv.Rd
+++ b/man/scale_fill_comfort_pmv.Rd
@@ -28,3 +28,25 @@ scale_fill_comfort_pmv(
 \description{
 A diverging blue-white-red fill scale centered on PMV 0.
 }
+\examples{
+# Use the default PMV colour scale.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_overlay(n = c(45, 30)) +
+    scale_fill_comfort_pmv(name = "PMV")
+
+# Focus the legend on the usual comfort range.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_overlay(n = c(45, 30)) +
+    scale_fill_comfort_pmv(limits = c(-1.5, 1.5), name = "PMV")
+
+# Use a custom diverging palette.
+ggpsychro(tdb_lim = c(15, 35), hum_lim = c(0, 24)) +
+    geom_comfort_overlay(n = c(45, 30)) +
+    scale_fill_comfort_pmv(
+        low = "#2166AC",
+        mid = "white",
+        high = "#B2182B",
+        name = "PMV"
+    )
+
+}

--- a/man/stat.Rd
+++ b/man/stat.Rd
@@ -197,8 +197,13 @@ states <- data.frame(
 ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
     stat_relhum(aes(x = tdb, relhum = relhum), data = states)
 
-# The stats can also be used from ordinary ggplot2 geoms.
 wetbulb_line <- data.frame(tdb = 18:30, wetbulb = 16)
+ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
+    geom_grid_wetbulb() +
+    stat_wetbulb(aes(x = tdb, wetbulb = wetbulb),
+        data = wetbulb_line, geom = "line")
+
+# The stats can also be used from ordinary ggplot2 geoms.
 ggpsychro(tdb_lim = c(10, 35), hum_lim = c(0, 25)) +
     geom_grid_wetbulb() +
     geom_line(aes(x = tdb, wetbulb = wetbulb),

--- a/man/stat_psychro_bin.Rd
+++ b/man/stat_psychro_bin.Rd
@@ -221,6 +221,12 @@ ggpsychro(d, tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
     )
 
 ggpsychro(d, tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
+    stat_psychro_bin(
+        aes(dry_bulb, relhum = relative_humidity, fill = after_stat(hours)),
+        binwidth = c(2, 2)
+    )
+
+ggpsychro(d, tdb_lim = c(15, 30), hum_lim = c(0, 20)) +
     geom_psychro_tile(
         aes(dry_bulb, relhum = relative_humidity, value = cooling_load,
             fill = after_stat(value)),

--- a/man/theme.Rd
+++ b/man/theme.Rd
@@ -77,9 +77,20 @@ psychrochart's ASHRAE and minimal chart styles.
 Custom theme for psychrometric chart.
 }
 \examples{
-theme_psychro()
-theme_psychro_ashrae()
-theme_psychro_minimal()
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    theme_grey_psychro()
+
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    theme_gray_psychro()
+
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    theme_psychro()
+
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    theme_psychro_ashrae()
+
+ggpsychro(tdb_lim = c(0, 50), hum_lim = c(0, 30)) +
+    theme_psychro_minimal()
 
 }
 \seealso{

--- a/man/trans.Rd
+++ b/man/trans.Rd
@@ -38,4 +38,5 @@ plot(relhum_trans("SI"), xlim = c(0, 100))
 plot(wetbulb_trans("SI"), xlim = c(-50, 40))
 plot(vappres_trans("SI"), xlim = c(1000, 4000))
 plot(specvol_trans("SI"), xlim = c(0.8, 1))
+plot(enthalpy_trans("SI"), xlim = c(1000, 2000))
 }


### PR DESCRIPTION
## Summary

Improve reference documentation so exported user-facing helpers have runnable examples, and organize pkgdown reference pages by psychrometric workflow area.

## Changes

- Expand roxygen examples for comfort models, comfort overlays, psychrometric stats, scales, labels, themes, zones, and protractor guides.
- Regenerate Rd files from roxygen comments.
- Add pkgdown reference groups for core chart construction, psychrometric equations, data layers, comfort APIs, scales, themes, and extension topics.
