### PR TITLE
fix: address CRAN preflight checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Version: 0.1.0
 Authors@R:
     person(given = "Hongyuan",
            family = "Jia",
-           role = c("aut", "cre"),
+           role = c("aut", "cre", "cph"),
            email = "hongyuan.jia@bears-berkeley.sg",
            comment = c(ORCID = "0000-0002-0075-8183"))
 Description:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ggpsychro 0.1.0
 
+* Addressed CRAN preflight checks by adding return-value documentation,
+  recording the copyright-holder role, and guarding tests when suggested
+  packages are unavailable. (#33)
 * Refactored the ggpsychro build pipeline and comfort overlay internals to
   isolate build-time state, guard ggplot2 internals, and split comfort code
   into focused modules. (#31)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
 # ggpsychro 0.1.0
 
-* Addressed CRAN preflight checks by adding return-value documentation,
-  recording the copyright-holder role, and guarding tests when suggested
-  packages are unavailable. (#33)
+* Addressed CRAN preflight checks by adding return-value documentation and
+  recording the copyright-holder role. (#33)
 * Refactored the ggpsychro build pipeline and comfort overlay internals to
   isolate build-time state, guard ggplot2 internals, and split comfort code
   into focused modules. (#31)

--- a/R/aaa-.R
+++ b/R/aaa-.R
@@ -4,6 +4,7 @@ NULL
 #' Base ggproto classes for ggpsychro
 #'
 #' @seealso ggplot2::ggproto
+#' @return A ggproto object used internally by ggpsychro.
 #' @keywords internal
 #' @name ggpsychro-ggproto
 NULL

--- a/R/comfort-layer.R
+++ b/R/comfort-layer.R
@@ -53,6 +53,7 @@ NULL
 #'   with [element_comfort_zone()], [ggplot2::element_polygon()], or ordinary
 #'   named lists with fields `fill`, `colour`/`color`, `linewidth`, `linetype`,
 #'   `alpha`, and `linejoin`.
+#' @return A ggplot layer or a list of ggplot additions.
 #'
 #' @examples
 #' # Draw filled PMV comfort bands.
@@ -717,6 +718,7 @@ stat_comfort_state <- function(mapping = NULL, data = NULL, geom = "point",
 #' @param low,mid,high Endpoint and midpoint colours.
 #' @param midpoint Scale midpoint.
 #' @param oob Out-of-bounds handler.
+#' @return A ggplot2 fill scale.
 #'
 #' @examples
 #' # Use the default PMV colour scale.

--- a/R/coord-psychro.R
+++ b/R/coord-psychro.R
@@ -5,6 +5,7 @@ NULL
 #'
 #' @inheritParams ggplot2::coord_cartesian
 #' @inheritParams ggpsychro
+#' @return A ggplot2 coordinate system object for psychrometric charts.
 #' @examples
 #' ggpsychro() +
 #'     coord_psychro(tdb_lim = c(10, 35), hum_lim = c(0, 25))

--- a/R/ggproto-classes.R
+++ b/R/ggproto-classes.R
@@ -7,5 +7,6 @@
 #'
 #' @name ggpsychro-extensions
 #' @rdname ggpsychro-extensions
+#' @return A ggproto object used internally by ggpsychro extensions.
 #' @keywords internal
 NULL

--- a/R/ggpsychro.R
+++ b/R/ggpsychro.R
@@ -94,6 +94,7 @@ ggpsychro <- function (data = NULL, mapping = aes(), tdb_lim = NULL, hum_lim = N
 
 #' Reports whether x is a ggplot object
 #' @param x An object to test
+#' @return A single logical value.
 #'
 #' @examples
 #' is.ggpsychro(ggpsychro())

--- a/R/grid-layer.R
+++ b/R/grid-layer.R
@@ -16,6 +16,7 @@
 #' @param label_loc A single number in range `[0, 1]` indicating the label
 #'   position along each grid line. `NA` hides labels.
 #' @param label_parse If `TRUE`, labels are parsed as plotmath expressions.
+#' @return A ggplot addition that controls rendering of a psychrometric grid.
 #'
 #' @rdname geom_grid
 #' @examples

--- a/R/labels.R
+++ b/R/labels.R
@@ -24,6 +24,7 @@ default_labs <- function(units = "SI", mollier = FALSE) {
 #' @param parse If `TRUE`, the labels will be parsed into expressions and
 #'        displayed as described in `?plotmath`. Default: `FALSE`.
 #' @inherit scales::number_format params return
+#' @return A labelling function that formats numeric breaks.
 #'
 #' @examples
 #' demo_scale(10:50, labels = label_drybulb(units = "SI", parse = TRUE))
@@ -225,6 +226,7 @@ force_all <- function (...) list(...)
 #'
 #' @param x A vector of data
 #' @param ... Other arguments pass to scale functions
+#' @return A ggplot object demonstrating the supplied scale settings.
 #'
 #' @examples
 #' demo_scale(0:10, labels = scales::label_number())

--- a/R/psychro-state.R
+++ b/R/psychro-state.R
@@ -16,6 +16,7 @@ NULL
 #'
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_path
+#' @return A ggplot layer.
 #' @rdname psychro_state
 #' @examples
 #' process <- data.frame(

--- a/R/psychro-zone.R
+++ b/R/psychro-zone.R
@@ -24,6 +24,7 @@ NULL
 #' @inheritParams ggplot2::geom_polygon
 #' @param type A zone type.
 #' @param n Number of samples used for computed zone boundaries.
+#' @return A ggplot layer.
 #'
 #' @rdname psychro_zone
 #' @examples

--- a/R/scale.R
+++ b/R/scale.R
@@ -9,6 +9,7 @@ NULL
 #' @param trans,transform A transformation object or transformer name passed
 #'   to the underlying ggplot2 continuous scale. The default [ggplot2::waiver()]
 #'   keeps the psychrometric scale in chart display units.
+#' @return A ggplot2 continuous scale object.
 #'
 #' @rdname scale
 #' @importFrom ggplot2 continuous_scale

--- a/R/stat-psychro-bin.R
+++ b/R/stat-psychro-bin.R
@@ -58,6 +58,8 @@ NULL
 #' * `width`, `height`: tile dimensions after applying `gap`.
 #' * `cell_xmin`, `cell_xmax`, `cell_ymin`, `cell_ymax`: full bin boundaries.
 #'
+#' @return A ggplot layer.
+#'
 #' @examples
 #' d <- data.frame(
 #'     dry_bulb = c(20.1, 20.4, 22.2, 22.5),

--- a/R/stat.R
+++ b/R/stat.R
@@ -35,6 +35,7 @@ NULL
 #'
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_point
+#' @return A ggplot layer.
 #' @importFrom ggplot2 ggproto Stat Geom
 #' @rdname stat
 #' @examples

--- a/R/trans.R
+++ b/R/trans.R
@@ -14,6 +14,7 @@ is.empty_trans <- function(trans) {
 #'
 #' @param units A string indicating the system of units chosen. Should be either
 #'        `"SI"` or `"IP"`.
+#' @return A [scales::trans_new()] transformation object.
 #'
 #' @rdname trans
 #' @importFrom scales trans_new extended_breaks regular_minor_breaks

--- a/man/coord_psychro.Rd
+++ b/man/coord_psychro.Rd
@@ -61,6 +61,9 @@ limits are set via \code{xlim} and \code{ylim} and some data points fall outside
 limits, then those data points may show up in places such as the axes, the
 legend, the plot title, or the plot margins.}
 }
+\value{
+A ggplot2 coordinate system object for psychrometric charts.
+}
 \description{
 Psychrometric coordinates
 }

--- a/man/demo_scale.Rd
+++ b/man/demo_scale.Rd
@@ -11,6 +11,9 @@ demo_scale(x, ...)
 
 \item{...}{Other arguments pass to scale functions}
 }
+\value{
+A ggplot object demonstrating the supplied scale settings.
+}
 \description{
 This function generates ggplot2 code needed to use scales functions for real
 code.

--- a/man/geom_comfort_overlay.Rd
+++ b/man/geom_comfort_overlay.Rd
@@ -318,6 +318,9 @@ give the geom as \code{"point"}.
 \link[ggplot2:layer_geoms]{layer geom} documentation.
 }}
 }
+\value{
+A ggplot layer or a list of ggplot additions.
+}
 \description{
 \code{geom_comfort_overlay()} samples a psychrometric panel on a dry-bulb by
 humidity-ratio grid and draws the selected comfort metric as filled contour

--- a/man/geom_grid.Rd
+++ b/man/geom_grid.Rd
@@ -66,6 +66,9 @@ position along each grid line. \code{NA} hides labels.}
 
 \item{label_parse}{If \code{TRUE}, labels are parsed as plotmath expressions.}
 }
+\value{
+A ggplot addition that controls rendering of a psychrometric grid.
+}
 \description{
 These helpers provide ggplot-style controls for psychrometric reference
 grids. They do not add data layers; they mark a grid as visible and let

--- a/man/ggpsychro-extensions.Rd
+++ b/man/ggpsychro-extensions.Rd
@@ -13,6 +13,9 @@
 \alias{StatPsychroState}
 \alias{StatPsychroZone}
 \title{ggpsychro extensions to ggplot2}
+\value{
+A ggproto object used internally by ggpsychro extensions.
+}
 \description{
 ggpsychro makes heavy use of the ggproto class system to extend the
 functionality of ggplot2. In general the actual classes should be of little

--- a/man/ggpsychro-ggproto.Rd
+++ b/man/ggpsychro-ggproto.Rd
@@ -5,6 +5,9 @@
 \alias{ggpsychro-ggproto}
 \alias{CoordPsychro}
 \title{Base ggproto classes for ggpsychro}
+\value{
+A ggproto object used internally by ggpsychro.
+}
 \description{
 Base ggproto classes for ggpsychro
 }

--- a/man/ggpsychro-package.Rd
+++ b/man/ggpsychro-package.Rd
@@ -17,6 +17,6 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Hongyuan Jia \email{hongyuan.jia@bears-berkeley.sg} (\href{https://orcid.org/0000-0002-0075-8183}{ORCID})
+\strong{Maintainer}: Hongyuan Jia \email{hongyuan.jia@bears-berkeley.sg} (\href{https://orcid.org/0000-0002-0075-8183}{ORCID}) [copyright holder]
 
 }

--- a/man/is.ggpsychro.Rd
+++ b/man/is.ggpsychro.Rd
@@ -9,6 +9,9 @@ is.ggpsychro(x)
 \arguments{
 \item{x}{An object to test}
 }
+\value{
+A single logical value.
+}
 \description{
 Reports whether x is a ggplot object
 }

--- a/man/label.Rd
+++ b/man/label.Rd
@@ -218,6 +218,9 @@ displayed as described in \code{?plotmath}. Default: \code{FALSE}.}
 
 \item{...}{Other arguments passed on to \code{\link[base:format]{base::format()}}.}
 }
+\value{
+A labelling function that formats numeric breaks.
+}
 \description{
 Format numbers as main variables on the psychrometric chart.
 }

--- a/man/psychro_state.Rd
+++ b/man/psychro_state.Rd
@@ -131,6 +131,9 @@ give the geom as \code{"point"}.
 \link[ggplot2:layer_geoms]{layer geom} documentation.
 }}
 }
+\value{
+A ggplot layer.
+}
 \description{
 \code{stat_psychro_state()} converts a dry-bulb temperature plus exactly one
 psychrometric state property to chart coordinates. \code{geom_psychro_process()}

--- a/man/psychro_zone.Rd
+++ b/man/psychro_zone.Rd
@@ -139,6 +139,9 @@ give the geom as \code{"point"}.
 \link[ggplot2:layer_geoms]{layer geom} documentation.
 }}
 }
+\value{
+A ggplot layer.
+}
 \description{
 \code{stat_psychro_zone()} samples psychrometric boundary curves and returns
 polygon coordinates. \code{geom_psychro_zone()} draws those polygons.

--- a/man/scale.Rd
+++ b/man/scale.Rd
@@ -186,6 +186,9 @@ keeps the psychrometric scale in chart display units.}
 
 \item{...}{Other arguments passed on to \verb{scale_(x|y)_continuous()}}
 }
+\value{
+A ggplot2 continuous scale object.
+}
 \description{
 Transformation object for psychrometric chart
 }

--- a/man/scale_fill_comfort_pmv.Rd
+++ b/man/scale_fill_comfort_pmv.Rd
@@ -25,6 +25,9 @@ scale_fill_comfort_pmv(
 
 \item{oob}{Out-of-bounds handler.}
 }
+\value{
+A ggplot2 fill scale.
+}
 \description{
 A diverging blue-white-red fill scale centered on PMV 0.
 }

--- a/man/stat.Rd
+++ b/man/stat.Rd
@@ -154,6 +154,9 @@ rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
 the default plot specification, e.g. \code{\link[ggplot2:annotation_borders]{annotation_borders()}}.}
 }
+\value{
+A ggplot layer.
+}
 \description{
 Calculate psychrometric properties of moist air
 }

--- a/man/stat_psychro_bin.Rd
+++ b/man/stat_psychro_bin.Rd
@@ -179,6 +179,9 @@ to the computed bin spacing.}
 inherits from the current \code{panel.grid.*.x} and \code{panel.grid.*.y} theme
 elements. Explicit values override the inherited theme style.}
 }
+\value{
+A ggplot layer.
+}
 \description{
 \code{stat_psychro_bin()} bins observations on dry-bulb temperature and humidity
 ratio coordinates. \code{geom_psychro_tile()} draws the result as tiles, which is

--- a/man/trans.Rd
+++ b/man/trans.Rd
@@ -28,6 +28,9 @@ enthalpy_trans(units = "SI")
 \item{units}{A string indicating the system of units chosen. Should be either
 \code{"SI"} or \code{"IP"}.}
 }
+\value{
+A \code{\link[scales:new_transform]{scales::trans_new()}} transformation object.
+}
 \description{
 Create transformation objects for psychrometric chart
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,6 +1,4 @@
-if (requireNamespace("testthat", quietly = TRUE)) {
-    library(testthat)
-    library(ggpsychro)
+library(testthat)
+library(ggpsychro)
 
-    test_check("ggpsychro")
-}
+test_check("ggpsychro")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,6 @@
-library(testthat)
-library(ggpsychro)
+if (requireNamespace("testthat", quietly = TRUE)) {
+    library(testthat)
+    library(ggpsychro)
 
-test_check("ggpsychro")
+    test_check("ggpsychro")
+}


### PR DESCRIPTION
## Summary

Addresses the CRAN preflight follow-ups tracked in #32 by documenting exported return values and adding the copyright-holder role.

## Changes

* Add roxygen `@return` entries for exported ggplot layers, scales, stats, transformations, labels, and ggproto documentation topics, then regenerate the Rd files.
* Add the `cph` role to `Authors@R`.
