### PR TITLE
fix: address checktor findings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ggpsychro
-Title: A 'ggplot2' Extension for Making Psychrometric Charts
+Title: Create Psychrometric Charts
 Version: 0.1.0
 Authors@R:
     person(given = "Hongyuan",
@@ -9,10 +9,10 @@ Authors@R:
            comment = c(ORCID = "0000-0002-0075-8183"))
 Description:
     Provides 'ggplot2' coordinates, layers, scales, themes, and presets for
-    creating psychrometric charts. The package supports SI and IP units,
-    psychrometric grids, state points, process lines, zones, and thermal comfort
-    overlays for heating, ventilation, air conditioning, and building
-    performance workflows.
+    creating psychrometric charts. The package supports metric and inch-pound
+    unit systems, psychrometric grids, state points, process lines, zones, and
+    thermal comfort overlays for heating, ventilation, air conditioning, and
+    building performance workflows.
 Depends:
     R (>= 4.1),
     ggplot2 (>= 4.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggpsychro 0.1.0
 
+* Addressed `checktor` CRAN-preflight findings in package metadata and
+  psychrometric axis labels. (#38)
 * Refined comfort overlay APIs and documentation, added Givoni-Milne strategy
   variants with custom comfort anchors, and added CI-only ggplot2 compatibility
   checks. (#37)

--- a/R/labels.R
+++ b/R/labels.R
@@ -1,9 +1,9 @@
 default_labs <- function(units = "SI", mollier = FALSE) {
     if (units == "SI") {
-        lab_x <- expression("Dry-bulb temperature (" * degree * C * ")")
+        lab_x <- expression("Dry-bulb temperature (" * degree * "C" * ")")
         lab_y <- expression("Humidity ratio (" * g[m] * "/" * kg[da] * ")")
     } else if (units == "IP") {
-        lab_x <- expression("Dry-bulb temperature (" * degree * F * ")")
+        lab_x <- expression("Dry-bulb temperature (" * degree * "F" * ")")
         lab_y <- expression("Humidity ratio (" * gr[m] * "/" * lb[da] * ")")
     }
 


### PR DESCRIPTION
## Summary

Addresses `checktor` CRAN-preflight diagnostics before submitting `ggpsychro` to CRAN.

## Changes

- Rewrites the `DESCRIPTION` title and description to avoid article/title-case/acronym diagnostics.
- Quotes plotmath temperature unit symbols in `R/labels.R` so `checktor` no longer flags bare `F` as `FALSE`.